### PR TITLE
Add login cli command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "gitpython==3.1.36",
     "keyring==24.2.0",
     "loguru==0.7.2",
+    "python-frontmatter==1.0.0",
     "rich==13.6.0",
     "typer==0.9.0",
 ]
@@ -37,7 +38,6 @@ optional-dependencies = {dev = [
     "mypy",
     "pre-commit",
     "pytest",
-    "python-frontmatter==6.0.1",
     "ruff",
     "tox>=4",
     "twine",
@@ -195,7 +195,6 @@ legacy_tox_ini = """
     deps =
         pytest
         pytest-cov
-        python-frontmatter
 
     [tox]
     env_list =

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -28,7 +28,7 @@ from qw.remote_repo.service import (
 app = typer.Typer()
 
 
-class LogLevel(Enum):
+class LogLevel(str, Enum):
     """Log Level."""
 
     ERROR = "error"
@@ -54,7 +54,7 @@ def main(
         typer.Option(
             help="Level of logging to output",
         ),
-    ] = None,
+    ] = LogLevel.INFO,
 ):
     """
     Process global options.

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -123,7 +123,6 @@ def login(*, force: bool = False):
 
     access_token = Prompt.ask(
         f"Please copy the access token for {conf['service']}",
-        password=True,
     )
 
     set_qw_password(conf["user_name"], conf["repo_name"], access_token)

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -117,15 +117,16 @@ def login(*, force: bool = False):
     existing_access_token = get_qw_password(conf["user_name"], conf["repo_name"])
 
     if existing_access_token and not force:
-        # currently shows the existing access token in the stack trace, could delete it here?
-        msg = "Access token already exists, rerun with '--force' if you want to override it."
-        raise QwError(msg)
+        typer.echo(
+            "Access token already exists, rerun with '--force' if you want to override it.",
+        )
+    else:
+        access_token = Prompt.ask(
+            f"Please copy the access token for {conf['service']}",
+        )
 
-    access_token = Prompt.ask(
-        f"Please copy the access token for {conf['service']}",
-    )
+        set_qw_password(conf["user_name"], conf["repo_name"], access_token)
 
-    set_qw_password(conf["user_name"], conf["repo_name"], access_token)
     check()
 
 

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -117,6 +117,7 @@ def login(*, force: bool = False):
     existing_access_token = get_qw_password(conf["user_name"], conf["repo_name"])
 
     if existing_access_token and not force:
+        # currently shows the existing access token in the stack trace, could delete it here?
         msg = "Access token already exists, rerun with '--force' if you want to override it."
         raise QwError(msg)
 

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -111,7 +111,15 @@ def check():
 
 
 @app.command()
-def login(*, force: bool = False):
+def login(
+    *,
+    force: Annotated[
+        Optional[bool],
+        typer.Option(
+            help="Replace existing access credentials.",
+        ),
+    ] = False,
+):
     """Add access credentials for the remote repository."""
     conf = store.read_configuration()
     existing_access_token = get_qw_password(conf["user_name"], conf["repo_name"])

--- a/src/qw/local_store/keyring.py
+++ b/src/qw/local_store/keyring.py
@@ -1,0 +1,18 @@
+"""Local keyring access for password storing and retrieval."""
+import keyring
+
+from qw.base import QwError
+
+
+def get_qw_password(organisation: str, repository: str):
+    """Get the QW password for the repo from local keychain."""
+    return keyring.get_password("qw", f"{organisation}/{repository}")
+
+
+def set_qw_password(organisation: str, repository: str, password: str):
+    """Set the QW password for the repo in local keychain."""
+    cleaned_password = password.strip(" ")
+    if not cleaned_password:
+        msg = "Access token was empty, please add again."
+        raise QwError(msg)
+    keyring.set_password("qw", f"{organisation}/{repository}", cleaned_password)

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -73,7 +73,7 @@ class GitHubService(qw.remote_repo.service.GitService):
             Issue(issue) for issue in self.gh.issues_on(self.username, self.reponame)
         ]
 
-    def check(self):
+    def check(self) -> bool:
         """Check that the credentials can connect to the service."""
         try:
             logger.info(self.issues)
@@ -83,3 +83,4 @@ class GitHubService(qw.remote_repo.service.GitService):
         except AuthenticationFailed as exception:
             msg = "Could not connect to Github, please check that your access token is correct and has not expired"
             raise QwError(msg) from exception
+        return True

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -1,11 +1,13 @@
 """GitHub concrete service."""
 
 import github3
-import keyring
+from github3.exceptions import AuthenticationFailed
+from loguru import logger
 
 import qw.remote_repo.service
 from qw.base import QwError
 from qw.design_stages.categories import RemoteItemType
+from qw.local_store.keyring import get_qw_password
 
 
 class Issue(qw.remote_repo.service.Issue):
@@ -53,7 +55,7 @@ class GitHubService(qw.remote_repo.service.GitService):
     def __init__(self, conf):
         """Log in with the gh auth token."""
         super().__init__(conf)
-        token = keyring.get_password("qw", f"{self.username}/{self.reponame}")
+        token = get_qw_password(self.username, self.reponame)
         if not token:
             msg = "Could not find a token in keyring."
             raise QwError(msg)
@@ -70,3 +72,14 @@ class GitHubService(qw.remote_repo.service.GitService):
         return [
             Issue(issue) for issue in self.gh.issues_on(self.username, self.reponame)
         ]
+
+    def check(self):
+        """Check that the credentials can connect to the service."""
+        try:
+            logger.info(self.issues)
+        except ConnectionError as exception:
+            msg = "Could not connect to Github, please check internet connection"
+            raise QwError(msg) from exception
+        except AuthenticationFailed as exception:
+            msg = "Could not connect to Github, please check that your access token is correct and has not expired"
+            raise QwError(msg) from exception

--- a/src/qw/remote_repo/factory.py
+++ b/src/qw/remote_repo/factory.py
@@ -21,7 +21,7 @@ def get_service(conf: dict | None = None) -> GitService:
     if name == str(Service.GITHUB):
         return GitHubService(conf)
     if name == str(Service.TEST):
-        return FileSystemService(conf)
+        return FileSystemService("test")
 
     msg = f"Do not know how to connect to the {name} service!"
     raise QwError(

--- a/src/qw/remote_repo/factory.py
+++ b/src/qw/remote_repo/factory.py
@@ -1,4 +1,5 @@
 """Factory for making git hosting services."""
+from pathlib import Path
 
 from qw.base import QwError
 from qw.local_store.main import LocalStore
@@ -21,7 +22,7 @@ def get_service(conf: dict | None = None) -> GitService:
     if name == str(Service.GITHUB):
         return GitHubService(conf)
     if name == str(Service.TEST):
-        return FileSystemService("test")
+        return FileSystemService(Path(conf["resource_base"]), "test")
 
     msg = f"Do not know how to connect to the {name} service!"
     raise QwError(

--- a/src/qw/remote_repo/factory.py
+++ b/src/qw/remote_repo/factory.py
@@ -4,6 +4,7 @@ from qw.base import QwError
 from qw.local_store.main import LocalStore
 from qw.remote_repo._github import GitHubService
 from qw.remote_repo.service import GitService, Service
+from qw.remote_repo.test_service import FileSystemService
 
 
 def get_service(conf: dict | None = None) -> GitService:
@@ -19,6 +20,9 @@ def get_service(conf: dict | None = None) -> GitService:
         )
     if name == str(Service.GITHUB):
         return GitHubService(conf)
+    if name == str(Service.TEST):
+        return FileSystemService(conf)
+
     msg = f"Do not know how to connect to the {name} service!"
     raise QwError(
         msg,

--- a/src/qw/remote_repo/service.py
+++ b/src/qw/remote_repo/service.py
@@ -178,3 +178,8 @@ class GitService(ABC):
     def issues(self) -> list[Issue]:
         """Get all issues for the repository."""
         ...
+
+    @abstractmethod
+    def check(self):
+        """Check that the credentials can connect to the service."""
+        ...

--- a/src/qw/remote_repo/service.py
+++ b/src/qw/remote_repo/service.py
@@ -180,6 +180,6 @@ class GitService(ABC):
         ...
 
     @abstractmethod
-    def check(self):
+    def check(self) -> bool:
         """Check that the credentials can connect to the service."""
         ...

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -51,10 +51,12 @@ class FileSystemService(GitService):
     """The FileSystem Service."""
 
     def __init__(self, target_dir: str, root_dir: Path | None = None):
-        """Set up mocked GitHub service reading from local filesystem."""
+        """Set up mocked service reading from local filesystem."""
         super().__init__({"user_name": "file", "repo_name": "system"})
         if not root_dir:
-            root_dir = Path(__file__).parents[1] / "resources" / "design_stages"
+            root_dir = (
+                Path(__file__).parents[3] / "tests" / "resources" / "design_stages"
+            )
         self.resource_path = root_dir / target_dir
 
     def get_issue(self, number: int):
@@ -75,3 +77,7 @@ class FileSystemService(GitService):
         """Get all issues in the root path."""
         mdx_files = sorted(self.resource_path.glob("*.mdx"))
         return [FileSystemIssue(file) for file in mdx_files]
+
+    def check(self):
+        """Check that the credentials can connect to the service."""
+        return True

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -50,13 +50,9 @@ class FileSystemIssue(Issue):
 class FileSystemService(GitService):
     """The FileSystem Service."""
 
-    def __init__(self, target_dir: str, root_dir: Path | None = None):
+    def __init__(self, root_dir: Path, target_dir: str):
         """Set up mocked service reading from local filesystem."""
         super().__init__({"user_name": "file", "repo_name": "system"})
-        if not root_dir:
-            root_dir = (
-                Path(__file__).parents[3] / "tests" / "resources" / "design_stages"
-            )
         self.resource_path = root_dir / target_dir
 
     def get_issue(self, number: int):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,14 @@ def qw_store_builder(empty_local_store) -> Callable[[list[dict]], LocalStore]:
         return empty_local_store
 
     return _add_to_store
+
+
+@pytest.fixture()
+def mock_user_input(monkeypatch):
+    """Mock user input from prompt, uses internal method to be able to take in arguments."""
+
+    def _take_input(responses: list[str]):
+        answers = iter(responses)
+        monkeypatch.setattr("builtins.input", lambda: next(answers))
+
+    return _take_input

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures used by across the entire test suite."""
+import json
 from collections.abc import Callable
 
 import pytest
@@ -11,8 +12,16 @@ def empty_local_store(tmp_path_factory: pytest.TempPathFactory) -> LocalStore:
     """Create tmp dir with .qw child dir, returning a local store instance."""
     repo_dir = tmp_path_factory.mktemp("fake_repo")
     store = LocalStore(repo_dir)
-    store.get_or_create_qw_dir()
-    # Currently no conf.json created, but could create a config if we required it
+    qw_dir = store.get_or_create_qw_dir()
+    config_data = {
+        "repo_url": "git@github.com:local/repo.git",
+        "repo_name": "repo",
+        "user_name": "local",
+        "service": "Service.TEST",
+    }
+    config_path = qw_dir / "conf.json"
+    with config_path.open("w") as handler:
+        json.dump(config_data, handler)
 
     return store
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures used by across the entire test suite."""
 import json
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -18,6 +19,7 @@ def empty_local_store(tmp_path_factory: pytest.TempPathFactory) -> LocalStore:
         "repo_name": "repo",
         "user_name": "local",
         "service": "Service.TEST",
+        "resource_base": str(Path(__file__).parent / "resources" / "design_stages"),
     }
     config_path = qw_dir / "conf.json"
     with config_path.open("w") as handler:

--- a/tests/design_stages/test_main.py
+++ b/tests/design_stages/test_main.py
@@ -4,7 +4,7 @@ import pytest
 
 from qw.base import QwError
 from qw.design_stages.main import Requirement, get_local_stages, get_remote_stages
-from tests.helpers.mock_service import FileSystemService
+from qw.remote_repo.test_service import FileSystemService
 
 
 def test_build_from_dict(

--- a/tests/design_stages/test_main.py
+++ b/tests/design_stages/test_main.py
@@ -1,4 +1,5 @@
 """Testing main functionality of design stages."""
+from pathlib import Path
 
 import pytest
 
@@ -35,6 +36,9 @@ def test_filesystem_service_builds_requirement():
     When the requirement is parsed from the service
     Then there should be one Requirement from the service
     """
-    service = FileSystemService("single_requirement")
+    service = FileSystemService(
+        Path(__file__).parents[1] / "resources" / "design_stages",
+        "single_requirement",
+    )
     stages = get_remote_stages(service)
     assert len(stages) == 1

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,1 +1,0 @@
-"""Testing-only functionality."""

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -1,4 +1,5 @@
 """Test for changes."""
+from pathlib import Path
 
 import pytest
 
@@ -14,14 +15,19 @@ def single_requirement() -> list[dict]:
 
      Useful for writing to tmp filesystem using qw_store_builder.
     """
-    service = FileSystemService("single_requirement")
+    service = FileSystemService(
+        Path(__file__).parent / "resources" / "design_stages",
+        "single_requirement",
+    )
     stages = get_remote_stages(service)
     return [x.to_dict() for x in stages]
 
 
 def handler_with_single_requirement(store, base_dir=None) -> ChangeHandler:
     """Build ChangeHandler with store, and if defined, a base directory."""
-    service = FileSystemService("single_requirement", base_dir)
+    if not base_dir:
+        base_dir = Path(__file__).parent / "resources" / "design_stages"
+    service = FileSystemService(base_dir, "single_requirement")
     return ChangeHandler(service, store)
 
 

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -4,7 +4,7 @@ import pytest
 
 from qw.changes import ChangeHandler
 from qw.design_stages.main import get_remote_stages
-from tests.helpers.mock_service import FileSystemService
+from qw.remote_repo.test_service import FileSystemService
 
 
 @pytest.fixture()
@@ -17,17 +17,6 @@ def single_requirement() -> list[dict]:
     service = FileSystemService("single_requirement")
     stages = get_remote_stages(service)
     return [x.to_dict() for x in stages]
-
-
-@pytest.fixture()
-def mock_user_input(monkeypatch):
-    """Mock user input from prompt, uses internal method to be able to take in arguments."""
-
-    def _take_input(responses: list[str]):
-        answers = iter(responses)
-        monkeypatch.setattr("builtins.input", lambda: next(answers))
-
-    return _take_input
 
 
 def handler_with_single_requirement(store, base_dir=None) -> ChangeHandler:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,16 +53,18 @@ def test_login_pat_exists(mock_user_input, mock_keyvault_with_value):
     Given password already exists in the mocked store.
 
     When login is run without a `--force` flag
-    Then an exception should be thrown
+    Then this should be reported without being overriden
     """
     pw = "I'm a test password"
-    mock_keyvault_with_value([pw, pw])
+    mock_keyvault_with_value([pw])
     mock_user_input([pw])
 
     result = runner.invoke(app, ["login"])
 
     assert "Access token already exists" in " ".join(result.exception.args)
     assert result.exit_code != 0
+    assert "Access token already exists" in result.stdout
+    assert result.exit_code == 0
 
 
 def test_login_force(mock_user_input, mock_keyvault_with_value):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,99 @@
+"""Test command line interface functionality."""
+import pytest
+from typer.testing import CliRunner
+
+from qw.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def mock_keyvault_with_value(monkeypatch):
+    """Mock keyvault, so that we don't alter the real one, and return an acceptable value."""
+
+    def _take_input(responses: list[str]):
+        values = iter(responses)
+        monkeypatch.setattr(
+            "keyring.get_password",
+            lambda service_name, username: next(values),  # noqa: ARG005
+        )
+        monkeypatch.setattr(
+            "keyring.set_password",
+            lambda service_name, username, password: None,  # noqa: ARG005
+        )
+
+    return _take_input
+
+
+@pytest.fixture(autouse=True)
+def _local_store(monkeypatch, empty_local_store):
+    """Set the qw local store to be the empty local store."""
+    monkeypatch.setattr("qw.cli.store", empty_local_store)
+
+
+def test_login_success(mock_user_input, mock_keyvault_with_value):
+    """
+    Given no password exists in the mocked store.
+
+    When login is run with a password entered
+    Then the application should be able to connect to the local store
+    """
+    pw = "I'm a test password"
+    mock_keyvault_with_value([None, pw])
+    mock_user_input([pw])
+
+    result = runner.invoke(app, ["login"])
+
+    assert "Can connect" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_login_pat_exists(mock_user_input, mock_keyvault_with_value):
+    """
+    Given password already exists in the mocked store.
+
+    When login is run without a `--force` flag
+    Then an exception should be thrown
+    """
+    pw = "I'm a test password"
+    mock_keyvault_with_value([pw, pw])
+    mock_user_input([pw])
+
+    result = runner.invoke(app, ["login"])
+
+    assert "Access token already exists" in " ".join(result.exception.args)
+    assert result.exit_code != 0
+
+
+def test_login_force(mock_user_input, mock_keyvault_with_value):
+    """
+    Given password already exists in the mocked store.
+
+    When login is run with a `--force` flag
+    Then the application should be able to connect to the local store
+    """
+    pw = "I'm a test password"
+    mock_keyvault_with_value([pw, pw])
+    mock_user_input([pw])
+
+    result = runner.invoke(app, ["login", "--force"])
+
+    assert "Can connect" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_login_whitespace_password(mock_user_input, mock_keyvault_with_value):
+    """
+    Given no password exists in mocked keychain.
+
+    When a whitespace password is entered
+    Then an exception should be thrown
+    """
+    pw_input = "  "
+    mock_keyvault_with_value([None])
+    mock_user_input([pw_input])
+
+    result = runner.invoke(app, ["login"])
+
+    assert "Access token was empty" in " ".join(result.exception.args)
+    assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,8 +61,6 @@ def test_login_pat_exists(mock_user_input, mock_keyvault_with_value):
 
     result = runner.invoke(app, ["login"])
 
-    assert "Access token already exists" in " ".join(result.exception.args)
-    assert result.exit_code != 0
     assert "Access token already exists" in result.stdout
     assert result.exit_code == 0
 


### PR DESCRIPTION
closes #14 
- Went for being able to mock out the store within qw.cli, so that we can test the CLI fairly easily. Also moved the local filesystem service to the source code so that this can be handled by the CLI. 
- Not sure if we want to hide the existing PAT if it exists, as currently it's shown in the stack trace, though might be useful to be able to see it for debugging?