### PR TITLE
Copy github templates using `qw configure` command

### DIFF
--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -1,13 +1,16 @@
 """GitHub concrete service."""
+from collections.abc import Iterable
+from itertools import chain
+from pathlib import Path
 
 import github3
+import keyring
 from github3.exceptions import AuthenticationFailed
 from loguru import logger
 
 import qw.remote_repo.service
 from qw.base import QwError
 from qw.design_stages.categories import RemoteItemType
-from qw.local_store.keyring import get_qw_password
 
 
 class Issue(qw.remote_repo.service.Issue):
@@ -55,7 +58,7 @@ class GitHubService(qw.remote_repo.service.GitService):
     def __init__(self, conf):
         """Log in with the gh auth token."""
         super().__init__(conf)
-        token = get_qw_password(self.username, self.reponame)
+        token = keyring.get_password("qw", f"{self.username}/{self.reponame}")
         if not token:
             msg = "Could not find a token in keyring."
             raise QwError(msg)
@@ -84,3 +87,10 @@ class GitHubService(qw.remote_repo.service.GitService):
             msg = "Could not connect to Github, please check that your access token is correct and has not expired"
             raise QwError(msg) from exception
         return True
+
+    @property
+    def template_paths(self) -> Iterable[Path]:
+        """Paths for templates to copy to the service."""
+        markdown = self.qw_resources.glob("templates/.github/**/*.md")
+        yaml = self.qw_resources.glob("templates/.github/**/*.yml")
+        return chain(markdown, yaml)

--- a/src/qw/remote_repo/service.py
+++ b/src/qw/remote_repo/service.py
@@ -7,7 +7,9 @@ the project managment interest resides.
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from enum import Enum
+from pathlib import Path
 
 import git
 
@@ -167,6 +169,7 @@ class GitService(ABC):
         self.conf = conf
         self.username = conf["user_name"]
         self.reponame = conf["repo_name"]
+        self.qw_resources = Path(__file__).parents[2] / "resources"
 
     @abstractmethod
     def get_issue(self, number: int) -> Issue:
@@ -179,7 +182,12 @@ class GitService(ABC):
         """Get all issues for the repository."""
         ...
 
+    @property
     @abstractmethod
-    def check(self) -> bool:
-        """Check that the credentials can connect to the service."""
+    def template_paths(self) -> Iterable[Path]:
+        """Paths for templates to copy to the service."""
         ...
+
+    def relative_target_path(self, base_folder: str, resource_path: Path) -> Path:
+        """Find the relative path that a resource should be copied to."""
+        return resource_path.relative_to(self.qw_resources / base_folder)

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -1,4 +1,6 @@
 """Mock service functionality to allow reading from local filesystem in tests rather than hitting APIs constantly."""
+from collections.abc import Iterable
+from itertools import chain
 from pathlib import Path
 
 import frontmatter
@@ -77,3 +79,10 @@ class FileSystemService(GitService):
     def check(self):
         """Check that the credentials can connect to the service."""
         return True
+
+    @property
+    def template_paths(self) -> Iterable[Path]:
+        """Paths for templates to copy to the service."""
+        markdown = self.qw_resources.glob("templates/.github/**/*.md")
+        yaml = self.qw_resources.glob("templates/.github/**/*.yml")
+        return chain(markdown, yaml)

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/design-input.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/design-input.yml
@@ -1,0 +1,58 @@
+name: Design input
+description: Create a new design input
+labels: ["qw-design-input"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Let's add a new design input to the project
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the design input
+      placeholder: Specific requirement information
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component does this relate to?
+      options:
+        - System
+    validations:
+      required: true
+  - type: dropdown
+    id: requirement-type
+    attributes:
+      label: Type of requirement
+      description: What is classification of the requirement?
+      options:
+        - Functional
+        - System inputs and outputs
+        - Application programming interface
+        - Alarms and warnings
+        - Security
+        - User interface
+        - Data definition and database
+        - Installation and acceptance
+        - Operation methods and maintenance
+        - Networking
+        - User maintenance
+        - Regulatory
+    validations:
+      required: true
+  - type: textarea
+    id: user-need
+    attributes:
+      label: Parent user need
+      description: Enter the User need github issue number that the design input contributes to, in the form `#1`
+      placeholder: "#1"
+    validations:
+      required: true
+  - type: textarea
+    id: other-information
+    attributes:
+      label: Other information
+      description: Any other information, ignored by the QW tool

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/non-qw.md
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/non-qw.md
@@ -1,0 +1,5 @@
+---
+name: Non QW item
+about: Anything that doesn't affect the medical device
+labels: qw-ignore
+---

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/user-need.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/user-need.yml
@@ -1,0 +1,27 @@
+name: User need
+description: Create a new user need
+labels: ["qw-user-need"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Let's add a new user need to the project
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the user need
+      placeholder: The user needs...
+    validations:
+      required: true
+  - type: textarea
+    id: design-inputs
+    attributes:
+      label: Design inputs
+      description: If design inputs already exist, enter the github issue number(s) in the form `#3` or `#3 #4`
+      placeholder: "#3 #4"
+  - type: textarea
+    id: other-information
+    attributes:
+      label: Other information
+      description: Any other information, ignored by the QW tool

--- a/src/resources/templates/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/resources/templates/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,5 @@
 ### Description
 
-### Description
-
 <!--
    replace with a description used in qw and which issues this addresses.
    e.g. Closes #4 or Addresses part of #3

--- a/src/resources/templates/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/resources/templates/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+### Description
+
+### Description
+
+<!--
+   replace with a description used in qw and which issues this addresses.
+   e.g. Closes #4 or Addresses part of #3
+-->
+
+### QW actions
+
+- [ ] Tagged with the qw design stage
+<!--
+  Please tag ths PR with `qw-design-output`, `qw-design-verification`, `qw-design-validation`,
+  or (if the change is not related to the medical device, ) `qw-ignore`  as appropriate.
+-->
+
+- [ ] Assigned PR to those who contributed to the work
+- [ ] Appropriate reviewers added to PR
+
+### Other information
+
+<!-- Ignored by wq -->

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,9 +26,10 @@ def mock_keyvault_with_value(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _local_store(monkeypatch, empty_local_store):
+def mocked_store(monkeypatch, empty_local_store):
     """Set the qw local store to be the empty local store."""
     monkeypatch.setattr("qw.cli.store", empty_local_store)
+    return empty_local_store
 
 
 def test_login_success(mock_user_input, mock_keyvault_with_value):
@@ -61,8 +62,6 @@ def test_login_pat_exists(mock_user_input, mock_keyvault_with_value):
 
     result = runner.invoke(app, ["login"])
 
-    assert "Access token already exists" in " ".join(result.exception.args)
-    assert result.exit_code != 0
     assert "Access token already exists" in result.stdout
     assert result.exit_code == 0
 
@@ -99,3 +98,59 @@ def test_login_whitespace_password(mock_user_input, mock_keyvault_with_value):
 
     assert "Access token was empty" in " ".join(result.exception.args)
     assert result.exit_code != 0
+
+
+def test_configure_adds_templates(mocked_store):
+    """
+    Given no templates exist in git root (tmpdir).
+
+    When `qw configure` is run
+    Then templates should be copied and the cli should exit without error
+    """
+    result = runner.invoke(app, ["configure"])
+
+    assert (
+        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "design-input.yml"
+    ).exists()
+    assert (mocked_store.base_dir / ".github" / "PULL_REQUEST_TEMPLATE.md").exists()
+    assert result.exit_code == 0
+
+
+def test_configure_throws_if_templates_exist(mocked_store):
+    """
+    Given the pull request template exists already.
+
+    When `qw configure` is run
+    Then an exception should be thrown and the other templates should not exist
+    """
+    existing_file = (
+        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "design-input.yml"
+    )
+    existing_file.parent.mkdir(parents=True)
+    existing_file.write_text("Now I exist.")
+
+    result = runner.invoke(app, ["configure"])
+
+    assert "Templates already exists" in " ".join(result.exception.args)
+    assert str(existing_file) in " ".join(result.exception.args)
+    assert result.exit_code != 0
+    assert not (mocked_store.base_dir / ".github" / "PULL_REQUEST_TEMPLATE.md").exists()
+
+
+def test_configure_force_templates_exist(mocked_store):
+    """
+    Given the pull request template exists already.
+
+    When `qw configure --force` is run
+    Then an exception should be thrown and the other templates should not exist
+    """
+    existing_file = (
+        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "design-input.yml"
+    )
+    existing_file.parent.mkdir(parents=True)
+    existing_file.write_text("Now I exist.")
+
+    result = runner.invoke(app, ["configure", "--force"])
+
+    assert (mocked_store.base_dir / ".github" / "PULL_REQUEST_TEMPLATE.md").exists()
+    assert result.exit_code == 0


### PR DESCRIPTION
closes #30 

Realised that we'd need to have a separate `configure` command, that works after we've done the `login` details saving. That way we can also use this same command to alter the github configuration using the github API. Currently implemented the test service to just use the GitHubService's templates as a nice way to test this.

I think once we've got that sorted, may remove the `qw check` command, and instead maybe add a `--check` flag to `qw login`?

Have used this version of qw to configure https://github.com/stefpiatek/dummy-medical-software, and added the changes to the repository

This should be merged after #29 as has a dependency on the login-cli branch