### PR TITLE
Customise system in requirements drop down

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     rev: v1.4.1
     hooks:
       - id: mypy
-        additional_dependencies: [numpy, pydantic, markdown, types-Markdown]
+        additional_dependencies:
+          [numpy, pydantic, markdown, types-Markdown, types-requests]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ qw init --repo github.com:username/reponame --service github
 >
 > INFO: Github actions for qw have been added to your ".github" directory
 >
-> INFO: Templates added to your ".github" directory: "User need", "Requirement", "Design output", "Pull request"
->
 > INFO: Please commit the files after you have finished your setup
 >
 > INFO: Rulesets and branch protection added for branches matching "main" to "stefpiatek/dummy-medical-software"
@@ -111,7 +109,9 @@ repository configured as the git remote named `upstream`.
   After you've done this, the system will check the personal access token. If you've configured for the remote
   URL <https://github.com/stefpiatek/dummy-medical-software> you would see:
 
-  > INFO: Can access "stefpiatek/dummy-medical-software"
+  > INFO there are currently 27 issues and PRs
+  >
+  > Can connect to remote repository :tada:
 
 ### Setup for a new user, on an existing project that uses QW
 
@@ -137,12 +137,16 @@ Drug dosage,D,Drug dosage calculation module.
 ```
 
 ```shell
-qw config --update-remote
+qw configure
 ```
 
-> INFO: Added "Drug dosage (D)" to local components, ensure that the updated file is committed.
+> INFO: there are currently 27 issues and PRs
 >
-> INFO: Added tag "qw-component-d" to GitHub
+> Can connect to remote repository :tada:
+>
+> INFO: Writing templates to local repository, force=False
+>
+> Local repository updated, please commit the changes made to your local repository.
 
 ## Configuration using Gitlab
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ qw init --repo github.com:username/reponame --service github
 ```
 
 > INFO: A ".qw" directory has been created
+>
 > INFO: Github actions for qw have been added to your ".github" directory
+>
 > INFO: Templates added to your ".github" directory: "User need", "Requirement", "Design output", "Pull request"
+>
 > INFO: Please commit the files after you have finished your setup
+>
 > INFO: Rulesets and branch protection added for branches matching "main" to "stefpiatek/dummy-medical-software"
 
 If you have a different development flow than pull requests into main/master then edit the `qw` ruleset for the repository,
@@ -137,6 +141,7 @@ qw config --update-remote
 ```
 
 > INFO: Added "Drug dosage (D)" to local components, ensure that the updated file is committed.
+>
 > INFO: Added tag "qw-component-d" to GitHub
 
 ## Configuration using Gitlab
@@ -285,22 +290,31 @@ An example incrementing a tag upon update:
 > - Parent User need: https://github.com/stefpiatek/dummy-medical-software/issues/5
 >
 > Would you like to increment the version? (y/n): <prompt response from user - y>
+>
 > INFO: Updated tag to "qw-v2"
+>
 > INFO: There are 2 design outputs that link to this Requirement, please ensure one of them has the "qw-v2" tag if it resolves the updated
 > information
 >
 > - https://github.com/stefpiatek/dummy-medical-software/pull/7
 > - https://github.com/stefpiatek/dummy-medical-software/pull/12
->   ...
->   INFO: :heavy_check_mark: 12 new QW items added to state
->   INFO: :heavy_check_mark: 47 QW items checked
->   INFO: Please commit the changes in the ".qw" directory
+>
+> ...
+>
+> INFO: :heavy_check_mark: 12 new QW items added to state
+>
+> INFO: :heavy_check_mark: 47 QW items checked
+>
+> INFO: Please commit the changes in the ".qw" directory
 
 Example response when the change is trivial and does not warrant a change in the version of the QW item:
 
 > ...
+>
 > Would you like to increment the version? (y/n): <prompt response from user - n>
+>
 > INFO: Tag kept at "qw-v1", data for the Requirement has been updated to the current state
+>
 > ...
 
 ### Creating a documentation release
@@ -323,8 +337,11 @@ qw release qms_docs
 ```
 
 > Creating a release for QW
+>
 > Creating "qms_docs" directory if it doesn't already exist, and overwriting any previously exported files
+>
 > INFO: :heavy_check_mark: 47 QW items checked
+>
 > INFO: :heavy_check_mark: Documents have been written to the "qms_docs" directory
 
 # FAQ and common issues
@@ -332,13 +349,3 @@ qw release qms_docs
 - Can I import an existing project into QW
   - There's nothing stopping this, though each issue and pull request would need to match the required format, and be tagged appropriately by the
     time you'd like to run a release. This may be a reasonable amount of work and we expect issues may need to be created.
--
-
-# Open questions
-
-- Which document parts are the most useful for export, and would we want the user to be able to edit the template (update styles and placeholder
-  text?)
-- Would the burndown chart be useful to get an overview for development?
-- Gate who can authorise a PR, or can anyone?
-- Should we include a change request at this stage, or keep it with the risk management side of things
-- closed not by a PR - would be useful to get a steer on what is required or most useful

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ repository configured as the git remote named `upstream`.
   | repository permissions | value          |
   | ---------------------- | -------------- |
   | Actions                | Read and write |
+  | Administration         | Read and write |
   | Contents               | Read-only      |
   | Issues                 | Read and write |
   | Metadata               | Read-only      |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "Jinja2==3.1.2",
     "github3.py==4.0.1",
     "gitpython==3.1.36",
     "keyring==24.2.0",

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -163,6 +163,9 @@ def configure(
     """Configure remote repository for qw (after initialisation and login credentials added)."""
     service = check()
     store.write_templates(service, force=force)
+    typer.echo(
+        "Local repository updated, please commit the changes made to your local repository.",
+    )
 
 
 if __name__ == "__main__":

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -98,7 +98,7 @@ def init(
     (host, username, reponame) = remote_address_to_host_user_repo(repo)
     if service is None:
         service = hostname_to_service(host)
-    store.write_to_config(repo, reponame, service, username)
+    store.initialise_qw_files(repo, reponame, service, username)
 
 
 @app.command()

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -19,7 +19,6 @@ from qw.local_store.keyring import get_qw_password, set_qw_password
 from qw.local_store.main import LocalStore
 from qw.remote_repo.factory import get_service
 from qw.remote_repo.service import (
-    GitService,
     Service,
     get_repo_url,
     hostname_to_service,
@@ -46,6 +45,14 @@ LOGELEVEL_TO_LOGURU = {
 }
 
 store = LocalStore()
+
+
+def _build_and_check_service():
+    conf = store.read_configuration()
+    service = get_service(conf)
+    service.check()
+    typer.echo("Can connect to the remote repository 🎉")
+    return service
 
 
 @app.callback()
@@ -102,14 +109,50 @@ def init(
 
 
 @app.command()
-def check() -> GitService:
-    """Check that qw can connect to the remote repository."""
-    conf = store.read_configuration()
-    service = get_service(conf)
-
-    service.check()
-    typer.echo("Can connect to the remote repository 🎉")
-    return service
+def check(
+    issue: Annotated[
+        Optional[int],
+        typer.Option(
+            help="Issue number to check",
+        ),
+    ] = None,
+    review_request: Annotated[
+        Optional[int],
+        typer.Option(
+            help="Review request number to check",
+        ),
+    ] = None,
+    token: Annotated[
+        Optional[str],
+        typer.Option(
+            help="CI access token to use for checking, otherwise will use local config",
+        ),
+    ] = None,
+    repository: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Repository in form '${organisation}/${repository}'",
+        ),
+    ] = None,
+) -> None:
+    """Check issue or pull request for any QW problems."""
+    if token and repository:
+        logger.info("Using CI access token for authorisation")
+    else:
+        logger.info(
+            "Using local qw config for authorisation because '--token' and '--repository' were not used",
+        )
+        _build_and_check_service()
+    # currently dummy function as doesn't need real functionality for configuration
+    if issue and review_request:
+        QwError(
+            "Check should only be run on an issue or a review_request, not both at the same time",
+        )
+    if not (issue or review_request):
+        QwError("Nothing given to check, please add a issue or review_request to check")
+    logger.success(
+        "Checks complete, stdout will contain a checklist of any problems found",
+    )
 
 
 @app.command()
@@ -137,7 +180,7 @@ def login(
 
         set_qw_password(conf["user_name"], conf["repo_name"], access_token)
 
-    check()
+    _build_and_check_service()
 
 
 @app.command()
@@ -161,10 +204,14 @@ def configure(
     ] = False,
 ):
     """Configure remote repository for qw (after initialisation and login credentials added)."""
-    service = check()
-    store.write_templates(service, force=force)
+    service = _build_and_check_service()
+    store.write_templates_and_ci(service, force=force)
     typer.echo(
         "Local repository updated, please commit the changes made to your local repository.",
+    )
+    service.update_remote(force=force)
+    typer.echo(
+        "Updated remote repository with rules",
     )
 
 

--- a/src/qw/local_store/__init__.py
+++ b/src/qw/local_store/__init__.py
@@ -1,1 +1,1 @@
-"""Local storage for qw."""
+"""Interacting with qw local storage, local repository and keychain."""

--- a/src/qw/local_store/_repository.py
+++ b/src/qw/local_store/_repository.py
@@ -1,0 +1,68 @@
+"""Configuration for local repository."""
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+from jinja2 import Template
+from loguru import logger
+
+from qw.base import QwError
+
+
+class RequirementComponents:
+    """Handle customising components for requirements."""
+
+    def __init__(self, qw_dir: Path):
+        """Initialise requirements component."""
+        self._component_file = qw_dir / "components.csv"
+        self._initial_data = {
+            "name": ["System"],
+            "short_code": ["X"],
+            "description": ["Whole system requirements"],
+        }
+        self._component_data = self._initial_data
+        if self._component_file.exists():
+            self._component_data = self._read_component_file(self._component_file)
+
+    def _read_component_file(self, component_file) -> dict[str, list[str]]:
+        with component_file.open("r") as handle:
+            reader = csv.DictReader(handle)
+            return self._parse_csv_data(reader)
+
+    def _parse_csv_data(self, reader):
+        output_data = defaultdict(list)
+        for row in reader:
+            for key in self._initial_data:
+                try:
+                    output_data[key].append(row[key].strip())
+                except KeyError as error:
+                    msg = (
+                        f"Could not find {key} in component specification in"
+                        f"{self._component_file}, please correct the file."
+                    )
+                    raise QwError(msg) from error
+        return output_data
+
+    def write_initial_data_if_not_exists(self):
+        """Write initial data to file path if it doesn't exist already."""
+        if self._component_file.exists():
+            logger.info(
+                "File already exists, not overwriting {path}",
+                self._component_file,
+            )
+            return
+        with self._component_file.open("w") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(self._initial_data.keys())
+            writer.writerows(zip(*self._initial_data.values(), strict=True))
+
+    def update_requirements_template(
+        self,
+        template_source: Path,
+        template_target: Path,
+    ):
+        """Update the requirements with the current component data."""
+        template = Template(template_source.read_text())
+        rendered_text = template.render(components=self._component_data["name"])
+        template_target.write_text(rendered_text)

--- a/src/qw/local_store/_repository.py
+++ b/src/qw/local_store/_repository.py
@@ -49,7 +49,7 @@ class RequirementComponents:
         if self._component_file.exists():
             logger.info(
                 "File already exists, not overwriting {path}",
-                self._component_file,
+                path=self._component_file,
             )
             return
         with self._component_file.open("w") as handle:

--- a/src/qw/local_store/main.py
+++ b/src/qw/local_store/main.py
@@ -98,9 +98,12 @@ class LocalStore:
         """Write to local data file."""
         _dump_json(data, self._data_path)
 
-    def write_templates(self, service: GitService, *, force: bool):
-        """Write templates to local repository."""
-        logger.info("Writing templates to local repository, force={force}", force=force)
+    def write_templates_and_ci(self, service: GitService, *, force: bool):
+        """Write templates and CI configuration to local repository."""
+        logger.info(
+            "Writing templates and CI config to local repository, force={force}",
+            force=force,
+        )
         should_not_exist = []
         target_paths = []
         for template in service.template_paths:

--- a/src/qw/local_store/main.py
+++ b/src/qw/local_store/main.py
@@ -1,21 +1,19 @@
 """Interaction with the qw local configuration and data storage."""
-import csv
 import pathlib
 import shutil
-from collections import defaultdict
 from pathlib import Path
 
-from jinja2 import Template
 from loguru import logger
 
 from qw.base import QwError
 from qw.local_store._json import _dump_json, _load_json
+from qw.local_store._repository import RequirementComponents
 from qw.local_store.directories import find_git_base_dir
 from qw.remote_repo.service import GitService, Service
 
 
 class LocalStore:
-    """Local storage of configuration and design stages."""
+    """Local storage of configuration, design stages and interaction with the local repository configuration."""
 
     _config_file = "conf.json"
     _data_file = "store.json"
@@ -134,61 +132,3 @@ class LocalStore:
                 )
             else:
                 shutil.copy(source_path, target_path)
-
-
-class RequirementComponents:
-    """Handle customising components for requirements."""
-
-    def __init__(self, qw_dir: Path):
-        """Initialise requirements component."""
-        self._component_file = qw_dir / "components.csv"
-        self._initial_data = {
-            "name": ["System"],
-            "short_code": ["X"],
-            "description": ["Whole system requirements"],
-        }
-        self._component_data = self._initial_data
-        if self._component_file.exists():
-            self._component_data = self._read_component_file(self._component_file)
-
-    def _read_component_file(self, component_file) -> dict[str, list[str]]:
-        with component_file.open("r") as handle:
-            reader = csv.DictReader(handle)
-            return self._parse_csv_data(reader)
-
-    def _parse_csv_data(self, reader):
-        output_data = defaultdict(list)
-        for row in reader:
-            for key in self._initial_data:
-                try:
-                    output_data[key].append(row[key].strip())
-                except KeyError as error:
-                    msg = (
-                        f"Could not find {key} in component specification in"
-                        f"{self._component_file}, please correct the file."
-                    )
-                    raise QwError(msg) from error
-        return output_data
-
-    def write_initial_data_if_not_exists(self):
-        """Write initial data to file path if it doesn't exist already."""
-        if self._component_file.exists():
-            logger.info(
-                "File already exists, not overwriting {path}",
-                self._component_file,
-            )
-            return
-        with self._component_file.open("w") as handle:
-            writer = csv.writer(handle)
-            writer.writerow(self._initial_data.keys())
-            writer.writerows(zip(*self._initial_data.values(), strict=True))
-
-    def update_requirements_template(
-        self,
-        template_source: Path,
-        template_target: Path,
-    ):
-        """Update the requirements with the current component data."""
-        template = Template(template_source.read_text())
-        rendered_text = template.render(components=self._component_data["name"])
-        template_target.write_text(rendered_text)

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -1,12 +1,16 @@
 """GitHub concrete service."""
+import json
 from collections.abc import Iterable
 from itertools import chain
 from pathlib import Path
 
 import github3
 import keyring
+import requests
 from github3.exceptions import AuthenticationFailed
+from jinja2 import Template
 from loguru import logger
+from requests import Response
 
 import qw.remote_repo.service
 from qw.base import QwError
@@ -58,11 +62,14 @@ class GitHubService(qw.remote_repo.service.GitService):
     def __init__(self, conf):
         """Log in with the gh auth token."""
         super().__init__(conf)
-        token = keyring.get_password("qw", f"{self.username}/{self.reponame}")
+        token = self._get_token()
         if not token:
             msg = "Could not find a token in keyring."
             raise QwError(msg)
         self.gh = github3.login(token=token)
+
+    def _get_token(self):
+        return keyring.get_password("qw", f"{self.username}/{self.reponame}")
 
     def get_issue(self, number: int):
         """Get the issue with the specified number."""
@@ -97,3 +104,98 @@ class GitHubService(qw.remote_repo.service.GitService):
         markdown = self.qw_resources.glob("templates/.github/**/*.md*")
         yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)
+
+    def update_remote(self, *, force: bool) -> None:
+        """Update remote repository with configration for qw tool."""
+        # load configured ruleset as a python dict
+        ruleset_template = self.qw_resources / "remote_repo/github/ruleset.json.jinja2"
+        json_template = Template(ruleset_template.read_text())
+        json_text = json_template.render(org=self.username, user=self.reponame)
+        json_bundle = json.loads(json_text)
+
+        # POST ruleset to GitHub
+        ruleset_url = (
+            f"https://api.github.com/repos/{self.username}/{self.reponame}/rulesets"
+        )
+        token = self._get_token()
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if not force:
+            self._create_new_ruleset(headers, json_bundle, ruleset_url)
+            return
+
+        existing_ruleset_response = requests.get(
+            ruleset_url,
+            headers=headers,
+            timeout=10,
+        )
+        if not self._is_valid_response(existing_ruleset_response):
+            self._throw_from_response(existing_ruleset_response)
+        existing_rulesets = existing_ruleset_response.json()
+        ruleset_id = None
+        for ruleset in existing_rulesets:
+            if json_bundle["name"] == ruleset["name"]:
+                ruleset_id = ruleset["id"]
+                break
+        if not ruleset_id:
+            self._create_new_ruleset(headers, json_bundle, ruleset_url)
+        else:
+            self._update_ruleset(headers, json_bundle, ruleset_url, ruleset_id)
+
+    def _is_valid_response(self, response: Response):
+        http_created = 201
+        http_updated = 200
+        return response.status_code in (http_created, http_updated)
+
+    def _throw_from_response(self, response: Response):
+        response_bundle = response.json()
+        msg = f"Error with GitHub rulesets - {response_bundle['message']}: {'. '.join(response_bundle['errors'])}"
+        raise QwError(
+            msg,
+        )
+
+    def _create_new_ruleset(self, headers: dict, json_bundle: dict, ruleset_url: str):
+        response = requests.post(
+            ruleset_url,
+            json=json_bundle,
+            headers=headers,
+            timeout=10,
+        )
+        # check response and raise if it hasn't been created
+        if self._is_valid_response(response):
+            logger.info(
+                "Added '{ruleset_name}' to {org}/{repo}",
+                ruleset_name=json_bundle["name"],
+                org=self.username,
+                repo=self.reponame,
+            )
+            return
+        self._throw_from_response(response)
+
+    def _update_ruleset(
+        self,
+        headers: dict,
+        json_bundle: dict,
+        ruleset_url: str,
+        ruleset_id: int,
+    ):
+        update_url = f"{ruleset_url}/{ruleset_id}"
+        response = requests.put(
+            update_url,
+            json=json_bundle,
+            headers=headers,
+            timeout=10,
+        )
+        # check response and raise if it hasn't been updated
+        if self._is_valid_response(response):
+            logger.info(
+                "Updated '{ruleset_name}' to {org}/{repo}",
+                ruleset_name=json_bundle["name"],
+                org=self.username,
+                repo=self.reponame,
+            )
+            return
+        self._throw_from_response(response)

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -91,6 +91,6 @@ class GitHubService(qw.remote_repo.service.GitService):
     @property
     def template_paths(self) -> Iterable[Path]:
         """Paths for templates to copy to the service."""
-        markdown = self.qw_resources.glob("templates/.github/**/*.md")
-        yaml = self.qw_resources.glob("templates/.github/**/*.yml")
+        markdown = self.qw_resources.glob("templates/.github/**/*.md*")
+        yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -79,7 +79,10 @@ class GitHubService(qw.remote_repo.service.GitService):
     def check(self) -> bool:
         """Check that the credentials can connect to the service."""
         try:
-            logger.info(self.issues)
+            logger.info(
+                "There are currently {issues} issues and PRs",
+                issues=len(self.issues),
+            )
         except ConnectionError as exception:
             msg = "Could not connect to Github, please check internet connection"
             raise QwError(msg) from exception

--- a/src/qw/remote_repo/service.py
+++ b/src/qw/remote_repo/service.py
@@ -191,3 +191,7 @@ class GitService(ABC):
     def relative_target_path(self, base_folder: str, resource_path: Path) -> Path:
         """Find the relative path that a resource should be copied to."""
         return resource_path.relative_to(self.qw_resources / base_folder)
+
+    @abstractmethod
+    def update_remote(self, *, force: bool) -> None:
+        """Update remote repository with configration for qw tool."""

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -83,6 +83,6 @@ class FileSystemService(GitService):
     @property
     def template_paths(self) -> Iterable[Path]:
         """Paths for templates to copy to the service."""
-        markdown = self.qw_resources.glob("templates/.github/**/*.md")
-        yaml = self.qw_resources.glob("templates/.github/**/*.yml")
+        markdown = self.qw_resources.glob("templates/.github/**/*.md*")
+        yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -86,3 +86,7 @@ class FileSystemService(GitService):
         markdown = self.qw_resources.glob("templates/.github/**/*.md*")
         yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)
+
+    def update_remote(self, *, force: bool) -> None:
+        """No implementation as no remote."""
+        ...

--- a/src/resources/remote_repo/github/ruleset.json.jinja2
+++ b/src/resources/remote_repo/github/ruleset.json.jinja2
@@ -1,0 +1,42 @@
+{
+  "name": "qw-pr-rules",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "{{ org }}/{{ user }}",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "dismiss_stale_reviews_on_push": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "qw-check-pr"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled:false

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/requirement.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/requirement.yml
@@ -1,11 +1,11 @@
-name: Design input
-description: Create a new design input
-labels: ["qw-design-input"]
+name: Requirement
+description: Create a requirement
+labels: ["qw-requirement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Let's add a new design input to the project
+        Let's add a new requirement to the project
   - type: textarea
     id: description
     attributes:
@@ -47,7 +47,7 @@ body:
     id: user-need
     attributes:
       label: Parent user need
-      description: Enter the User need github issue number that the design input contributes to, in the form `#1`
+      description: Enter the User need github issue number that the requirement contributes to, in the form `#1`
       placeholder: "#1"
     validations:
       required: true

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/requirement.yml.jinja2
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/requirement.yml.jinja2
@@ -19,8 +19,8 @@ body:
     attributes:
       label: Component
       description: Which component does this relate to?
-      options:
-        - System
+      options:{% for component in components %}
+        - {{ component }}{% endfor %}
     validations:
       required: true
   - type: dropdown

--- a/src/resources/templates/.github/workflows/qw-issue-check.yml
+++ b/src/resources/templates/.github/workflows/qw-issue-check.yml
@@ -1,0 +1,116 @@
+name: QW Issue Check
+# Checks to see if issue can be parsed by qw, and any outstanding problems with it.
+# If problems are found, it will update or create a comment with details of the problems
+# If previously problems found and now there are no problems, will update the existing comment
+# If no previous problems found and no problems currently, will do nothing
+
+on:
+  issues:
+    types:
+      - edited
+      - closed
+      - reopened
+
+# Allow GITHUB_TOKEN to write to issues
+permissions:
+  issues: write
+
+jobs:
+  qw-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' && !contains(github.event.issue.labels.*.name, 'qw-ignore') }}
+    outputs:
+      # "true" if problems found in parsing the issue metadata
+      problems: ${{ steps.qw.outputs.problems }}
+      # existing comment on the pull request
+      comment-id: ${{ steps.fc.outputs.comment-id }}
+    steps:
+      - name: Checkout qw
+        uses: actions/checkout@v3
+        with:
+          repository: UCL-ARC/qw
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: pip install .
+      - name: qw check
+        id: qw
+        run: |
+          echo '## Problems found from last edit by {{ .user }} on {{ .date | date "2006-01-02"}}' > problems-header.md &&
+          echo "" >> problems-header.md  &&
+          qw check --issue ${{ github.event.issue.number }}  --repository ${{ github.repository }} --token {{ secrets.GITHUB_TOKEN }} > problems.md &&
+          mkdir qw &&
+          cat problems-header.md problems.md > qw/problems.md &&
+          if [-z $(cat problems.md)]; then echo "problems=true" >> "$GITHUB_OUTPUT"; else echo "problems=" >> "$GITHUB_OUTPUT"; fi
+      - uses: actions/upload-artifact@master
+        if: ${{ steps.qw.outputs.problems != "" }}
+        with:
+          name: qw
+          path: qw
+      - name: Find Comment
+        # has output "comment-id"
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "## Problems found from last edit"
+
+  comment-problems:
+    runs-on: ubuntu-latest
+    needs: qw-check
+    if: ${{ needs.qw-check.outputs.problems != '' }}
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: qw
+          path: qw
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.8
+        with:
+          template: qw/problems.md
+          vars: |
+            user: ${{ github.actor }}
+            date: ${{ github.event.issue.updated_at }}
+      - name: Create Comment
+        if: needs.qw-check.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v3.1.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: ${{ steps.template.outputs.result }}
+      - name: Update Comment
+        if: needs.qw-check.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v3.1.0
+        with:
+          comment-id: ${{ needs.qw-check.outputs.comment-id }}
+          body: ${{ steps.template.outputs.result }}
+          edit-mode: replace
+
+  comment-fixed:
+    runs-on: ubuntu-latest
+    needs: qw-check
+    if: ${{ needs.qw-check.outputs.problems == '' && needs.qw-check.outputs.comment-id != '' }}
+    steps:
+      - name: Create resolved problems markdown file
+        run: |
+          mkdir qw &&
+          echo '## Problems fixed from edit by {{ .user }} on {{ .date | date "2006-01-02"}}' > qw/problems.md
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.8
+        with:
+          template: qw/problems.md
+          vars: |
+            user: ${{ github.actor }}
+            date: ${{ github.event.issue.updated_at }}
+      - name: Update Comment
+        if: needs.qw-check.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v3.1.0
+        with:
+          comment-id: ${{ needs.qw-check.outputs.comment-id }}
+          body: ${{ steps.template.outputs.result }}
+          edit-mode: replace

--- a/src/resources/templates/.github/workflows/qw-pr-check.yml
+++ b/src/resources/templates/.github/workflows/qw-pr-check.yml
@@ -1,0 +1,29 @@
+name: QW PR Check
+# Checks to see if a PR can be parsed by qw, and any outstanding problems with it.
+# If problems are found, the action will fail and give an error message of the problems found
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  qw-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'qw-ignore') }}
+    steps:
+      - name: Checkout qw
+        uses: actions/checkout@v3
+        with:
+          repository: UCL-ARC/qw
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: pip install .
+      - name: qw check
+        id: qw
+        run: |
+          qw check --review-request ${{ github.event.pull_request.number }}  --repository ${{ github.repository }} --token {{ secrets.GITHUB_TOKEN }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def empty_local_store(tmp_path_factory: pytest.TempPathFactory) -> LocalStore:
     with config_path.open("w") as handler:
         json.dump(config_data, handler)
 
-    return store
+    return LocalStore(repo_dir)
 
 
 @pytest.fixture()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import pytest
 from typer.testing import CliRunner
 
 from qw.cli import app
-from qw.local_store.main import RequirementComponents
+from qw.local_store._repository import RequirementComponents
 
 runner = CliRunner()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,7 +110,7 @@ def test_configure_adds_templates(mocked_store):
     result = runner.invoke(app, ["configure"])
 
     assert (
-        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "design-input.yml"
+        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "requirement.yml"
     ).exists()
     assert (mocked_store.base_dir / ".github" / "PULL_REQUEST_TEMPLATE.md").exists()
     assert result.exit_code == 0
@@ -124,7 +124,7 @@ def test_configure_throws_if_templates_exist(mocked_store):
     Then an exception should be thrown and the other templates should not exist
     """
     existing_file = (
-        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "design-input.yml"
+        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "requirement.yml"
     )
     existing_file.parent.mkdir(parents=True)
     existing_file.write_text("Now I exist.")
@@ -145,7 +145,7 @@ def test_configure_force_templates_exist(mocked_store):
     Then an exception should be thrown and the other templates should not exist
     """
     existing_file = (
-        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "design-input.yml"
+        mocked_store.base_dir / ".github" / "ISSUE_TEMPLATE" / "requirement.yml"
     )
     existing_file.parent.mkdir(parents=True)
     existing_file.write_text("Now I exist.")


### PR DESCRIPTION
- Went with Jinja2 templating, so that any other customisation is done easily, but open to feedback if you think that's overkill
- Realised still had `design-input` instead of `requirement` in templates so fixed that
- Broke up local repository templates into their own module, may end up renaming it when I get to github action copying but still seemed like a good place for it
- Will eventually remove `qw check` later on, but keeping in for now


Other fixes:

- Fixed documentation to show expected output correctly