### PR TITLE
Add github actions for checking issues and PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     rev: v1.4.1
     hooks:
       - id: mypy
-        additional_dependencies: [numpy, pydantic, markdown, types-Markdown]
+        additional_dependencies:
+          [numpy, pydantic, markdown, types-Markdown, types-requests]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ repository configured as the git remote named `upstream`.
   | repository permissions | value          |
   | ---------------------- | -------------- |
   | Actions                | Read and write |
+  | Administration         | Read and write |
   | Contents               | Read-only      |
   | Issues                 | Read and write |
   | Metadata               | Read-only      |

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -139,7 +139,9 @@ def check(
     if token and repository:
         logger.info("Using CI access token for authorisation")
     else:
-        logger.info("Using local qw config for authorisation")
+        logger.info(
+            "Using local qw config for authorisation because '--token' and '--repository' were not used",
+        )
         _build_and_check_service()
     # currently dummy function as doesn't need real functionality for configuration
     if issue and review_request:

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -113,7 +113,13 @@ def check(
     issue: Annotated[
         Optional[int],
         typer.Option(
-            help="Issue number to check.",
+            help="Issue number to check",
+        ),
+    ] = None,
+    review_request: Annotated[
+        Optional[int],
+        typer.Option(
+            help="Review request number to check",
         ),
     ] = None,
     token: Annotated[
@@ -123,7 +129,7 @@ def check(
         ),
     ] = None,
     repository: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             help="Repository in form '${organisation}/${repository}'",
         ),
@@ -136,8 +142,12 @@ def check(
         logger.info("Using local qw config for authorisation")
         _build_and_check_service()
     # currently dummy function as doesn't need real functionality for configuration
-    if not issue:
-        QwError("No issue number given")
+    if issue and review_request:
+        QwError(
+            "Check should only be run on an issue or a review_request, not both at the same time",
+        )
+    if not (issue or review_request):
+        QwError("Nothing given to check, please add a issue or review_request to check")
     logger.success(
         "Checks complete, stdout will contain a checklist of any problems found",
     )

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -209,6 +209,10 @@ def configure(
     typer.echo(
         "Local repository updated, please commit the changes made to your local repository.",
     )
+    service.update_remote(force=force)
+    typer.echo(
+        "Updated remote repository with rules",
+    )
 
 
 if __name__ == "__main__":

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -129,7 +129,7 @@ def check(
         ),
     ] = None,
     repository: Annotated[
-        str | None,
+        Optional[str],
         typer.Option(
             help="Repository in form '${organisation}/${repository}'",
         ),

--- a/src/qw/local_store/_repository.py
+++ b/src/qw/local_store/_repository.py
@@ -49,7 +49,7 @@ class RequirementComponents:
         if self._component_file.exists():
             logger.info(
                 "File already exists, not overwriting {path}",
-                self._component_file,
+                path=self._component_file,
             )
             return
         with self._component_file.open("w") as handle:

--- a/src/qw/local_store/main.py
+++ b/src/qw/local_store/main.py
@@ -98,9 +98,12 @@ class LocalStore:
         """Write to local data file."""
         _dump_json(data, self._data_path)
 
-    def write_templates(self, service: GitService, *, force: bool):
-        """Write templates to local repository."""
-        logger.info("Writing templates to local repository, force={force}", force=force)
+    def write_templates_and_ci(self, service: GitService, *, force: bool):
+        """Write templates and CI configuration to local repository."""
+        logger.info(
+            "Writing templates and CI config to local repository, force={force}",
+            force=force,
+        )
         should_not_exist = []
         target_paths = []
         for template in service.template_paths:

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -1,12 +1,16 @@
 """GitHub concrete service."""
+import json
 from collections.abc import Iterable
 from itertools import chain
 from pathlib import Path
 
 import github3
 import keyring
+import requests
 from github3.exceptions import AuthenticationFailed
+from jinja2 import Template
 from loguru import logger
+from requests import Response
 
 import qw.remote_repo.service
 from qw.base import QwError
@@ -58,11 +62,14 @@ class GitHubService(qw.remote_repo.service.GitService):
     def __init__(self, conf):
         """Log in with the gh auth token."""
         super().__init__(conf)
-        token = keyring.get_password("qw", f"{self.username}/{self.reponame}")
+        token = self._get_token()
         if not token:
             msg = "Could not find a token in keyring."
             raise QwError(msg)
         self.gh = github3.login(token=token)
+
+    def _get_token(self):
+        return keyring.get_password("qw", f"{self.username}/{self.reponame}")
 
     def get_issue(self, number: int):
         """Get the issue with the specified number."""
@@ -97,3 +104,98 @@ class GitHubService(qw.remote_repo.service.GitService):
         markdown = self.qw_resources.glob("templates/.github/**/*.md*")
         yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)
+
+    def update_remote(self, *, force: bool) -> None:
+        """Update remote repository with configration for qw tool."""
+        # load configured ruleset as a python dict
+        ruleset_template = self.qw_resources / "remote_repo/github/ruleset.json.jinja2"
+        json_template = Template(ruleset_template.read_text())
+        json_text = json_template.render(org=self.username, user=self.reponame)
+        json_bundle = json.loads(json_text)
+
+        # POST ruleset to GitHub
+        ruleset_url = (
+            f"https://api.github.com/repos/{self.username}/{self.reponame}/rulesets"
+        )
+        token = self._get_token()
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if not force:
+            self._create_new_ruleset(headers, json_bundle, ruleset_url)
+            return
+
+        existing_ruleset_response = requests.get(
+            ruleset_url,
+            headers=headers,
+            timeout=10,
+        )
+        if not self._is_valid_response(existing_ruleset_response):
+            self._throw_from_response(existing_ruleset_response)
+        existing_rulesets = existing_ruleset_response.json()
+        ruleset_id = None
+        for ruleset in existing_rulesets:
+            if json_bundle["name"] == ruleset["name"]:
+                ruleset_id = ruleset["id"]
+                break
+        if not ruleset_id:
+            self._create_new_ruleset(headers, json_bundle, ruleset_url)
+        else:
+            self._update_ruleset(headers, json_bundle, ruleset_url, ruleset_id)
+
+    def _is_valid_response(self, response: Response):
+        http_created = 201
+        http_updated = 200
+        return response.status_code in (http_created, http_updated)
+
+    def _throw_from_response(self, response: Response):
+        response_bundle = response.json()
+        msg = f"Error with GitHub rulesets - {response_bundle['message']}: {'. '.join(response_bundle['errors'])}"
+        raise QwError(
+            msg,
+        )
+
+    def _create_new_ruleset(self, headers: dict, json_bundle: dict, ruleset_url: str):
+        response = requests.post(
+            ruleset_url,
+            json=json_bundle,
+            headers=headers,
+            timeout=10,
+        )
+        # check response and raise if it hasn't been created
+        if self._is_valid_response(response):
+            logger.info(
+                "Added '{ruleset_name}' to {org}/{repo}",
+                ruleset_name=json_bundle["name"],
+                org=self.username,
+                repo=self.reponame,
+            )
+            return
+        self._throw_from_response(response)
+
+    def _update_ruleset(
+        self,
+        headers: dict,
+        json_bundle: dict,
+        ruleset_url: str,
+        ruleset_id: int,
+    ):
+        update_url = f"{ruleset_url}/{ruleset_id}"
+        response = requests.put(
+            update_url,
+            json=json_bundle,
+            headers=headers,
+            timeout=10,
+        )
+        # check response and raise if it hasn't been updated
+        if self._is_valid_response(response):
+            logger.info(
+                "Updated '{ruleset_name}' to {org}/{repo}",
+                ruleset_name=json_bundle["name"],
+                org=self.username,
+                repo=self.reponame,
+            )
+            return
+        self._throw_from_response(response)

--- a/src/qw/remote_repo/service.py
+++ b/src/qw/remote_repo/service.py
@@ -191,3 +191,7 @@ class GitService(ABC):
     def relative_target_path(self, base_folder: str, resource_path: Path) -> Path:
         """Find the relative path that a resource should be copied to."""
         return resource_path.relative_to(self.qw_resources / base_folder)
+
+    @abstractmethod
+    def update_remote(self, *, force: bool) -> None:
+        """Update remote repository with configration for qw tool."""

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -86,3 +86,7 @@ class FileSystemService(GitService):
         markdown = self.qw_resources.glob("templates/.github/**/*.md*")
         yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)
+
+    def update_remote(self, *, force: bool) -> None:
+        """No implementation as no remote."""
+        ...

--- a/src/resources/remote_repo/github/ruleset.json.jinja2
+++ b/src/resources/remote_repo/github/ruleset.json.jinja2
@@ -1,0 +1,42 @@
+{
+  "name": "qw-pr-rules",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "{{ org }}/{{ user }}",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "dismiss_stale_reviews_on_push": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "qw-check-pr"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled:false

--- a/src/resources/templates/.github/workflows/qw-issue-check.yml
+++ b/src/resources/templates/.github/workflows/qw-issue-check.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   qw-check:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && !contains(github.event.issue.labels.*.name, 'qw-ignore') }}
     outputs:
       # "true" if problems found in parsing the issue metadata
       problems: ${{ steps.qw.outputs.problems }}

--- a/src/resources/templates/.github/workflows/qw-issue-check.yml
+++ b/src/resources/templates/.github/workflows/qw-issue-check.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           echo '## Problems found from last edit by {{ .user }} on {{ .date | date "2006-01-02"}}' > problems-header.md &&
           echo "" >> problems-header.md  &&
-          qw check --issue ${{ github.event.issue.number }}  --repository ${{ github.repository }} > problems.md &&
+          qw check --issue ${{ github.event.issue.number }}  --repository ${{ github.repository }} --token {{ secrets.GITHUB_TOKEN }} > problems.md &&
           mkdir qw &&
           cat problems-header.md problems.md > qw/problems.md &&
           if [-z $(cat problems.md)]; then echo "problems=true" >> "$GITHUB_OUTPUT"; else echo "problems=" >> "$GITHUB_OUTPUT"; fi

--- a/src/resources/templates/.github/workflows/qw-issue-check.yml
+++ b/src/resources/templates/.github/workflows/qw-issue-check.yml
@@ -1,0 +1,116 @@
+name: QW Issue Check
+# Checks to see if issue can be parsed by qw, and any outstanding problems with it.
+# If problems are found, it will update or create a comment with details of the problems
+# If previously problems found and now there are no problems, will update the existing comment
+# If no previous problems found and no problems currently, will do nothing
+
+on:
+  issues:
+    types:
+      - edited
+      - closed
+      - reopened
+
+# Allow GITHUB_TOKEN to write to issues
+permissions:
+  issues: write
+
+jobs:
+  qw-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+    outputs:
+      # "true" if problems found in parsing the issue metadata
+      problems: ${{ steps.qw.outputs.problems }}
+      # existing comment on the pull request
+      comment-id: ${{ steps.fc.outputs.comment-id }}
+    steps:
+      - name: Checkout qw
+        uses: actions/checkout@v3
+        with:
+          repository: UCL-ARC/qw
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: pip install .
+      - name: qw check
+        id: qw
+        run: |
+          echo '## Problems found from last edit by {{ .user }} on {{ .date | date "2006-01-02"}}' > problems-header.md &&
+          echo "" >> problems-header.md  &&
+          qw check --issue ${{ github.event.issue.number }}  --repository ${{ github.repository }} > problems.md &&
+          mkdir qw &&
+          cat problems-header.md problems.md > qw/problems.md &&
+          if [-z $(cat problems.md)]; then echo "problems=true" >> "$GITHUB_OUTPUT"; else echo "problems=" >> "$GITHUB_OUTPUT"; fi
+      - uses: actions/upload-artifact@master
+        if: ${{ steps.qw.outputs.problems != "" }}
+        with:
+          name: qw
+          path: qw
+      - name: Find Comment
+        # has output "comment-id"
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "## Problems found from last edit"
+
+  comment-problems:
+    runs-on: ubuntu-latest
+    needs: qw-check
+    if: ${{ needs.qw-check.outputs.problems != '' }}
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: qw
+          path: qw
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.8
+        with:
+          template: qw/problems.md
+          vars: |
+            user: ${{ github.actor }}
+            date: ${{ github.event.issue.updated_at }}
+      - name: Create Comment
+        if: needs.qw-check.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v3.1.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: ${{ steps.template.outputs.result }}
+      - name: Update Comment
+        if: needs.qw-check.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v3.1.0
+        with:
+          comment-id: ${{ needs.qw-check.outputs.comment-id }}
+          body: ${{ steps.template.outputs.result }}
+          edit-mode: replace
+
+  comment-fixed:
+    runs-on: ubuntu-latest
+    needs: qw-check
+    if: ${{ needs.qw-check.outputs.problems == '' && needs.qw-check.outputs.comment-id != '' }}
+    steps:
+      - name: Create resolved problems markdown file
+        run: |
+          mkdir qw &&
+          echo '## Problems fixed from edit by {{ .user }} on {{ .date | date "2006-01-02"}}' > qw/problems.md
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.8
+        with:
+          template: qw/problems.md
+          vars: |
+            user: ${{ github.actor }}
+            date: ${{ github.event.issue.updated_at }}
+      - name: Update Comment
+        if: needs.qw-check.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v3.1.0
+        with:
+          comment-id: ${{ needs.qw-check.outputs.comment-id }}
+          body: ${{ steps.template.outputs.result }}
+          edit-mode: replace

--- a/src/resources/templates/.github/workflows/qw-pr-check.yml
+++ b/src/resources/templates/.github/workflows/qw-pr-check.yml
@@ -26,4 +26,4 @@ jobs:
       - name: qw check
         id: qw
         run: |
-          qw check --review-request ${{ github.event.pull_request.number }}  --repository ${{ github.repository }} > problems.md &&
+          qw check --review-request ${{ github.event.pull_request.number }}  --repository ${{ github.repository }} --token {{ secrets.GITHUB_TOKEN }}

--- a/src/resources/templates/.github/workflows/qw-pr-check.yml
+++ b/src/resources/templates/.github/workflows/qw-pr-check.yml
@@ -1,0 +1,29 @@
+name: QW PR Check
+# Checks to see if a PR can be parsed by qw, and any outstanding problems with it.
+# If problems are found, the action will fail and give an error message of the problems found
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  qw-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'qw-ignore') }}
+    steps:
+      - name: Checkout qw
+        uses: actions/checkout@v3
+        with:
+          repository: UCL-ARC/qw
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: pip install .
+      - name: qw check
+        id: qw
+        run: |
+          qw check --review-request ${{ github.event.pull_request.number }}  --repository ${{ github.repository }} > problems.md &&


### PR DESCRIPTION
Closes #33 

- Should be merged after #32 as it has a dependency on it
- Changed the `check` command to be used for the github actions checking
- As we can't use this until its merged into main, see https://github.com/stefpiatek/dummy-medical-software/blob/main/.github/workflows/issue_update.yml for a prototype where its doing most of the same things with extra debugging steps in the jobs
- Currently have gone for a dummy CLI interface to allow for implementation later on (but github actions should be able to run)
  - Nicely, loguru writes to stderr and typer.echo writes to stdout so can be piped into a file for the issue checking 
- Went with using the github actions repository as a CLI argument, but could clone the current repo and then read then the config? 
  - Feels easier to just use whats in the CI and avoid having to clone the current repo. 
  - Though if we wanted to check that the components match then we'd need to clone the repo config to get that anyway?