### PR TITLE
Add rulesets to github in configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     rev: v1.4.1
     hooks:
       - id: mypy
-        additional_dependencies: [numpy, pydantic, markdown, types-Markdown]
+        additional_dependencies:
+          [numpy, pydantic, markdown, types-Markdown, types-requests]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ repository configured as the git remote named `upstream`.
   | repository permissions | value          |
   | ---------------------- | -------------- |
   | Actions                | Read and write |
+  | Administration         | Read and write |
   | Contents               | Read-only      |
   | Issues                 | Read and write |
   | Metadata               | Read-only      |

--- a/src/qw/cli.py
+++ b/src/qw/cli.py
@@ -209,6 +209,10 @@ def configure(
     typer.echo(
         "Local repository updated, please commit the changes made to your local repository.",
     )
+    service.update_remote(force=force)
+    typer.echo(
+        "Updated remote repository with rules",
+    )
 
 
 if __name__ == "__main__":

--- a/src/qw/remote_repo/_github.py
+++ b/src/qw/remote_repo/_github.py
@@ -1,12 +1,16 @@
 """GitHub concrete service."""
+import json
 from collections.abc import Iterable
 from itertools import chain
 from pathlib import Path
 
 import github3
 import keyring
+import requests
 from github3.exceptions import AuthenticationFailed
+from jinja2 import Template
 from loguru import logger
+from requests import Response
 
 import qw.remote_repo.service
 from qw.base import QwError
@@ -58,11 +62,14 @@ class GitHubService(qw.remote_repo.service.GitService):
     def __init__(self, conf):
         """Log in with the gh auth token."""
         super().__init__(conf)
-        token = keyring.get_password("qw", f"{self.username}/{self.reponame}")
+        token = self._get_token()
         if not token:
             msg = "Could not find a token in keyring."
             raise QwError(msg)
         self.gh = github3.login(token=token)
+
+    def _get_token(self):
+        return keyring.get_password("qw", f"{self.username}/{self.reponame}")
 
     def get_issue(self, number: int):
         """Get the issue with the specified number."""
@@ -97,3 +104,98 @@ class GitHubService(qw.remote_repo.service.GitService):
         markdown = self.qw_resources.glob("templates/.github/**/*.md*")
         yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)
+
+    def update_remote(self, *, force: bool) -> None:
+        """Update remote repository with configration for qw tool."""
+        # load configured ruleset as a python dict
+        ruleset_template = self.qw_resources / "remote_repo/github/ruleset.json.jinja2"
+        json_template = Template(ruleset_template.read_text())
+        json_text = json_template.render(org=self.username, user=self.reponame)
+        json_bundle = json.loads(json_text)
+
+        # POST ruleset to GitHub
+        ruleset_url = (
+            f"https://api.github.com/repos/{self.username}/{self.reponame}/rulesets"
+        )
+        token = self._get_token()
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if not force:
+            self._create_new_ruleset(headers, json_bundle, ruleset_url)
+            return
+
+        existing_ruleset_response = requests.get(
+            ruleset_url,
+            headers=headers,
+            timeout=10,
+        )
+        if not self._is_valid_response(existing_ruleset_response):
+            self._throw_from_response(existing_ruleset_response)
+        existing_rulesets = existing_ruleset_response.json()
+        ruleset_id = None
+        for ruleset in existing_rulesets:
+            if json_bundle["name"] == ruleset["name"]:
+                ruleset_id = ruleset["id"]
+                break
+        if not ruleset_id:
+            self._create_new_ruleset(headers, json_bundle, ruleset_url)
+        else:
+            self._update_ruleset(headers, json_bundle, ruleset_url, ruleset_id)
+
+    def _is_valid_response(self, response: Response):
+        http_created = 201
+        http_updated = 200
+        return response.status_code in (http_created, http_updated)
+
+    def _throw_from_response(self, response: Response):
+        response_bundle = response.json()
+        msg = f"Error with GitHub rulesets - {response_bundle['message']}: {'. '.join(response_bundle['errors'])}"
+        raise QwError(
+            msg,
+        )
+
+    def _create_new_ruleset(self, headers: dict, json_bundle: dict, ruleset_url: str):
+        response = requests.post(
+            ruleset_url,
+            json=json_bundle,
+            headers=headers,
+            timeout=10,
+        )
+        # check response and raise if it hasn't been created
+        if self._is_valid_response(response):
+            logger.info(
+                "Added '{ruleset_name}' to {org}/{repo}",
+                ruleset_name=json_bundle["name"],
+                org=self.username,
+                repo=self.reponame,
+            )
+            return
+        self._throw_from_response(response)
+
+    def _update_ruleset(
+        self,
+        headers: dict,
+        json_bundle: dict,
+        ruleset_url: str,
+        ruleset_id: int,
+    ):
+        update_url = f"{ruleset_url}/{ruleset_id}"
+        response = requests.put(
+            update_url,
+            json=json_bundle,
+            headers=headers,
+            timeout=10,
+        )
+        # check response and raise if it hasn't been updated
+        if self._is_valid_response(response):
+            logger.info(
+                "Updated '{ruleset_name}' to {org}/{repo}",
+                ruleset_name=json_bundle["name"],
+                org=self.username,
+                repo=self.reponame,
+            )
+            return
+        self._throw_from_response(response)

--- a/src/qw/remote_repo/service.py
+++ b/src/qw/remote_repo/service.py
@@ -191,3 +191,7 @@ class GitService(ABC):
     def relative_target_path(self, base_folder: str, resource_path: Path) -> Path:
         """Find the relative path that a resource should be copied to."""
         return resource_path.relative_to(self.qw_resources / base_folder)
+
+    @abstractmethod
+    def update_remote(self, *, force: bool) -> None:
+        """Update remote repository with configration for qw tool."""

--- a/src/qw/remote_repo/test_service.py
+++ b/src/qw/remote_repo/test_service.py
@@ -86,3 +86,7 @@ class FileSystemService(GitService):
         markdown = self.qw_resources.glob("templates/.github/**/*.md*")
         yaml = self.qw_resources.glob("templates/.github/**/*.yml*")
         return chain(markdown, yaml)
+
+    def update_remote(self, *, force: bool) -> None:
+        """No implementation as no remote."""
+        ...

--- a/src/resources/remote_repo/github/ruleset.json.jinja2
+++ b/src/resources/remote_repo/github/ruleset.json.jinja2
@@ -1,0 +1,42 @@
+{
+  "name": "qw-pr-rules",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "{{ org }}/{{ user }}",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "dismiss_stale_reviews_on_push": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "required_status_checks": [
+          {
+            "context": "qw-check-pr"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
+++ b/src/resources/templates/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled:false


### PR DESCRIPTION
stacked on top of #34 
closes #35 

Overall was quite fun, not available in the github python API so direct via rest request. Could break up the github requests part into a separate class perhaps. Let me know, happy to go for that if it'd make it cleaner. 

Updated the README as extra permissions needed