### PR TITLE
Altering .qw/conf.json "checks" property for check severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and notify when manual verification should be rerun due to changes in requiremen
   - [x] Automated workflow
     - [x] Cannot merge without review
     - [x] Cannot merge without traceability to User Needs
-    - [ ] User configurability of checks
+    - [x] User configurability of checks
 - [ ] Automated test gathering?
   - [ ] Ensure automated tests pass before PR merge?
 - [ ] Extra information (in CSV files?)

--- a/README.md
+++ b/README.md
@@ -228,6 +228,41 @@ In the future we should have options such as `iso13485`, `dbc0129` and
 `management` to allow you to produce regulatory documents and management
 documents without having to build them yourself.
 
+### Customization of checks
+
+By default, `qw check` and the checks installed for gating PRs will fail if any check fails.
+This can be customized by editing `.qw\conf.json`. Look for the `"checks"` property,
+which looks something like this:
+
+```json
+{
+  "checks": {
+    "User need links have qw-user-need label": "error",
+    "User Need links must exist": "error",
+    "Closing Issues are Requirements": "error"
+  }
+}
+```
+
+You can turn behaviours off by changing `"error"` to `"off"`, or keep the
+check reporting but not preventing PRs from merging by changing `"error"`
+to `"warning"`:
+
+```json
+{
+  "checks": {
+    "User need links have qw-user-need label": "warning",
+    "User Need links must exist": "error",
+    "Closing Issues are Requirements": "off"
+  }
+}
+```
+
+If this change appears as part of a PR, the change will affect the workflow
+action gating this PR. For example, if your PR is failing checks, you can
+simply turn them off to get your PR through! It is currently up to the
+reviewer to make sure that this is not being abused!
+
 ## Configuration using Gitlab
 
 Gitlab is not supported yet. When it is, it will work both on gitlab.com and on

--- a/src/qw/design_stages/checks.py
+++ b/src/qw/design_stages/checks.py
@@ -6,11 +6,26 @@ when a PR is checked.
 """
 
 from collections.abc import Iterable
+from enum import Enum
 
 from loguru import logger
 
 from qw.design_stages._base import DesignBase
 from qw.design_stages.categories import RemoteItemType
+
+
+class CheckImpact(str, Enum):
+    """
+    Impact configuration for checks.
+
+    OFF: check is not run.
+    WARNING: check is run, but should not prevent a PR from being merged.
+    ERROR: check failure should prevent a PR from being merged.
+    """
+
+    OFF = "off"
+    WARNING = "warning"
+    ERROR = "error"
 
 
 class _Check:
@@ -56,16 +71,18 @@ _CHECKS: dict[str, list[_Check]] = {}
 class CheckResult:
     """Results from checking."""
 
-    def __init__(self, failures, object_count, check_count):
+    def __init__(self, errors, warnings, object_count, check_count):
         """
         Initialize.
 
         Has the following public properties:
-        :prop failures: human-readable failure list
+        :prop errors: human-readable error list
+        :prop warnings: human-readable warning list
         :prop object_count: the number of objects tested
         :prop check_count: the total number of checks run on all objects
         """
-        self.failures = failures
+        self.errors = errors
+        self.warnings = warnings
         self.object_count = object_count
         self.check_count = check_count
 
@@ -74,6 +91,7 @@ def run_checks(
     stages: list[type[DesignBase]],
     issues: set[int] | None = None,
     prs: set[int] | None = None,
+    impacts: dict[str, CheckImpact] | None = None,
     **_kwargs,
 ) -> CheckResult:
     """
@@ -83,6 +101,8 @@ def run_checks(
     :prs: Set of PR numbers to check.
     :return: List of error strings. Will be empty if no errors.
     """
+    if impacts is None:
+        impacts = {}
     class_dict_args: dict[str, dict[int, type[DesignBase]]] = {}
     for stage_class in DesignBase.__subclasses__():
         class_dict_args[stage_class.plural] = {}
@@ -90,6 +110,28 @@ def run_checks(
     for stage in stages:
         class_dict_args[stage.plural][stage.internal_id] = stage
     # Find the stages we actually want to test
+    wanted = get_wanted_stages(stages, issues, prs)
+    # Run the checks
+    count = 0
+    errors: list[str] = []
+    warnings: list[str] = []
+    for stage in wanted:
+        logger.debug("Checking {} {}", stage.__class__.__name__, stage.internal_id)
+        for check in _CHECKS.get(stage.__class__.__name__, []):
+            impact = impacts.get(check.title, CheckImpact.ERROR)
+            if impact != CheckImpact.OFF:
+                logger.debug(".. Check {}", check.title)
+                count += 1
+                result = check.apply_to(stage, **class_dict_args)
+                if impact == CheckImpact.ERROR:
+                    errors.extend(result)
+                else:
+                    warnings.extend(result)
+    return CheckResult(errors, warnings, len(wanted), count)
+
+
+def get_wanted_stages(stages, issues, prs) -> list[DesignBase]:
+    """Get all DesignStages from `issues` and `prs` whose ids exist in `stages`."""
     wanted: list[DesignBase] = []
     if prs is None and issues is None:
         wanted = stages
@@ -105,16 +147,12 @@ def run_checks(
                     wanted.append(stage)
             elif stage.internal_id in issues:
                 wanted.append(stage)
-    # Run the checks
-    count = 0
-    result: list[str] = []
-    for stage in wanted:
-        logger.debug("Checking {} {}", stage.__class__.__name__, stage.internal_id)
-        for check in _CHECKS.get(stage.__class__.__name__, []):
-            logger.debug(".. Check {}", check.title)
-            count += 1
-            result.extend(check.apply_to(stage, **class_dict_args))
-    return CheckResult(result, len(wanted), count)
+    return wanted
+
+
+def get_check_titles():
+    """Get the title for each check."""
+    return [check.title for (_class, checks) in _CHECKS.items() for check in checks]
 
 
 def check(title: str, fail_title: str, **kwargs):

--- a/src/qw/local_store/main.py
+++ b/src/qw/local_store/main.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from qw.base import QwError
+from qw.design_stages.checks import get_check_titles
 from qw.local_store._json import _dump_json, _load_json
 from qw.local_store._repository import (
     FailingRequirementComponents,
@@ -118,6 +119,9 @@ class LocalStore:
         self._write_config_file(repo, reponame, service, username)
         self._requirement_component.write_initial_data_if_not_exists()
 
+    def _get_default_check_impacts(self):
+        return {title: "error" for title in get_check_titles()}
+
     def _write_config_file(self, repo, reponame, service, username):
         """Write configuration to qw config file."""
         logger.debug(
@@ -131,6 +135,7 @@ class LocalStore:
             "repo_name": reponame,
             "user_name": username,
             "service": str(service),
+            "checks": self._get_default_check_impacts(),
         }
         _dump_json(conf, self._config_path)
 

--- a/tests/resources/design_stages/incorrect_links/pr4.mdx
+++ b/tests/resources/design_stages/incorrect_links/pr4.mdx
@@ -4,6 +4,7 @@ labels: []
 type: "request"
 number: 4
 ---
+
 ### Description
 
 Calculate warfarin based on age, gender and weight

--- a/tests/resources/design_stages/incorrect_links/pr4.mdx
+++ b/tests/resources/design_stages/incorrect_links/pr4.mdx
@@ -1,0 +1,26 @@
+---
+title: Calculate warfarin
+labels: []
+type: "request"
+number: 4
+---
+### Description
+
+Calculate warfarin based on age, gender and weight
+
+### Requirements closed
+
+- Closes #2
+
+### QW actions
+
+- [x] Assigned PR to those who contributed to the work
+- [x] Appropriate reviewers added to PR
+
+### Other information
+
+Closes a requirement
+
+### Paths
+
+/src/dose.c

--- a/tests/resources/design_stages/incorrect_links/pr5.mdx
+++ b/tests/resources/design_stages/incorrect_links/pr5.mdx
@@ -1,0 +1,27 @@
+---
+title: Some stuff
+labels: []
+type: "request"
+number: 5
+---
+### Description
+
+Does some mad stuff.
+
+### Requirements closed
+
+- Closes #1
+
+### QW actions
+
+- [x] Assigned PR to those who contributed to the work
+- [x] Appropriate reviewers added to PR
+
+### Other information
+
+Incorrectly closes a non-requirement
+
+### Paths
+
+/src/stuff.c
+/src/mad.c

--- a/tests/resources/design_stages/incorrect_links/pr5.mdx
+++ b/tests/resources/design_stages/incorrect_links/pr5.mdx
@@ -4,6 +4,7 @@ labels: []
 type: "request"
 number: 5
 ---
+
 ### Description
 
 Does some mad stuff.

--- a/tests/resources/design_stages/incorrect_links/requirement2.mdx
+++ b/tests/resources/design_stages/incorrect_links/requirement2.mdx
@@ -1,0 +1,18 @@
+---
+title: Calculate warfarin
+labels: ["qw-requirement"]
+type: "issue"
+number: 2
+---
+
+### Description
+
+Warfarin dosage should be calculated using based on patient age, gender and weight
+
+### Parent user need
+
+#1
+
+### Other information
+
+This link is correct.

--- a/tests/resources/design_stages/incorrect_links/requirement3.mdx
+++ b/tests/resources/design_stages/incorrect_links/requirement3.mdx
@@ -1,0 +1,18 @@
+---
+title: Input field for age.
+labels: ["qw-requirement"]
+type: "issue"
+number: 3
+---
+
+### Description
+
+Age input box accepts values from 0 to 130.
+
+### Parent user need
+
+#2
+
+### Other information
+
+This link is incorrect.

--- a/tests/resources/design_stages/incorrect_links/requirement6.mdx
+++ b/tests/resources/design_stages/incorrect_links/requirement6.mdx
@@ -1,0 +1,16 @@
+---
+title: Input field for age.
+labels: ["qw-requirement"]
+type: "issue"
+number: 6
+---
+
+### Description
+
+Beep after power on.
+
+### Parent user need
+
+### Other information
+
+No link at all.

--- a/tests/resources/design_stages/incorrect_links/userneed1.mdx
+++ b/tests/resources/design_stages/incorrect_links/userneed1.mdx
@@ -1,0 +1,12 @@
+---
+title: Deliver warfarin
+labels: ["qw-user-need"]
+type: "issue"
+number: 1
+---
+
+### Description
+
+Deliver the correct warfarin dosage.
+
+### Other information

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -4,23 +4,7 @@ from pathlib import Path
 import pytest
 
 from qw.changes import ChangeHandler
-from qw.design_stages.main import get_remote_stages
 from qw.remote_repo.test_service import FileSystemService
-
-
-@pytest.fixture()
-def single_requirement() -> list[dict]:
-    """
-    Read test resource in single_requirement and returns data as list of the single dict.
-
-     Useful for writing to tmp filesystem using qw_store_builder.
-    """
-    service = FileSystemService(
-        Path(__file__).parent / "resources" / "design_stages",
-        "single_requirement",
-    )
-    stages = get_remote_stages(service)
-    return [x.to_dict() for x in stages]
 
 
 def handler_with_single_requirement(store, base_dir=None) -> ChangeHandler:
@@ -43,7 +27,7 @@ def test_new_remote_items(empty_local_store):
     assert items
 
 
-def test_no_changes_to_items(qw_store_builder, single_requirement):
+def test_no_changes_to_items(qw_store_builder, test_design_stages):
     """
     Given A filesystem service with aRequirement and the same Requirement in the local store with no changes.
 
@@ -51,7 +35,7 @@ def test_no_changes_to_items(qw_store_builder, single_requirement):
     Then the output should have items in it.
     """
     # Arrange
-    store = qw_store_builder(single_requirement)
+    store = qw_store_builder(test_design_stages)
     handler = handler_with_single_requirement(store)
     # Act
     items = handler.combine_local_and_remote_items()
@@ -61,7 +45,7 @@ def test_no_changes_to_items(qw_store_builder, single_requirement):
 def test_do_not_remove_local_item(
     mock_user_input,
     qw_store_builder,
-    single_requirement,
+    test_design_stages,
 ):
     """
     Given A filesystem service without design stages and a local store with a Requirement.
@@ -70,7 +54,7 @@ def test_do_not_remove_local_item(
     Then the output should have items in it.
     """
     # Arrange
-    store = qw_store_builder(single_requirement)
+    store = qw_store_builder(test_design_stages)
     handler = handler_with_single_requirement(store, store._data_path)
     # Act
     mock_user_input(["n"])
@@ -82,7 +66,7 @@ def test_do_not_remove_local_item(
 def test_remove_local_item(
     mock_user_input,
     qw_store_builder,
-    single_requirement,
+    test_design_stages,
 ):
     """
     Given A filesystem service without design stages and a local store with a Requirement.
@@ -91,7 +75,7 @@ def test_remove_local_item(
     Then the output should have items in it.
     """
     # Arrange
-    store = qw_store_builder(single_requirement)
+    store = qw_store_builder(test_design_stages)
     handler = handler_with_single_requirement(store, store._data_path)
     # Act
     mock_user_input(["y"])
@@ -111,7 +95,7 @@ def test_remove_local_item(
 def test_same_items_with_changes(  # noqa: PLR0913 ignore too many functions to call
     mock_user_input,
     qw_store_builder,
-    single_requirement,
+    test_design_stages,
     response,
     expected_title,
     expected_version,
@@ -123,7 +107,7 @@ def test_same_items_with_changes(  # noqa: PLR0913 ignore too many functions to 
     Then the output stages should have the old title or new title, and increment the version as appropriate
     """
     # Arrange
-    input_data = single_requirement
+    input_data = test_design_stages
     input_data[0]["title"] = "Old title"
     input_data[0]["description"] = (
         "Warfarin dose should be calculated based on patient age, gender and  weight.\n"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,21 +1,42 @@
-"""Test check behaviour"""
+"""Test check behaviour."""
 import pytest
 
 from qw.cli import run_checks_with_impacts
 from qw.design_stages.main import get_local_stages
 
+
 @pytest.mark.parametrize(
-    ("empty_local_store", "test_design_stages", "expected_error_count", "expected_warning_count"), [
-        ({ "checks": {
-            "User need links have qw-user-need label": "warning",
-            "User Need links must exist": "error",
-            "Closing Issues are Requirements": "off",
-        }}, "incorrect_links", 1, 2),
-        ({ "checks": {
-            "User need links have qw-user-need label": "off",
-            "User Need links must exist": "off",
-            "Closing Issues are Requirements": "warning",
-        }}, "incorrect_links", 0, 2),
+    (
+        "empty_local_store",
+        "test_design_stages",
+        "expected_error_count",
+        "expected_warning_count",
+    ),
+    [
+        (
+            {
+                "checks": {
+                    "User need links have qw-user-need label": "warning",
+                    "User Need links must exist": "error",
+                    "Closing Issues are Requirements": "off",
+                },
+            },
+            "incorrect_links",
+            1,
+            2,
+        ),
+        (
+            {
+                "checks": {
+                    "User need links have qw-user-need label": "off",
+                    "User Need links must exist": "off",
+                    "Closing Issues are Requirements": "warning",
+                },
+            },
+            "incorrect_links",
+            0,
+            2,
+        ),
     ],
     indirect=["empty_local_store", "test_design_stages"],
 )
@@ -25,9 +46,14 @@ def test_check_severity(
     expected_error_count,
     expected_warning_count,
 ):
+    """
+    Test check severity configuration.
+
+    It should effect which errors and warnings are reported.
+    """
     store = qw_store_builder(test_design_stages)
     stages = get_local_stages(store)
     results = run_checks_with_impacts(store, stages)
-    assert results.object_count == 6
+    assert results.object_count == len(store.read_local_data())
     assert len(results.errors) == expected_error_count
     assert len(results.warnings) == expected_warning_count

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,33 @@
+"""Test check behaviour"""
+import pytest
+
+from qw.cli import run_checks_with_impacts
+from qw.design_stages.main import get_local_stages
+
+@pytest.mark.parametrize(
+    ("empty_local_store", "test_design_stages", "expected_error_count", "expected_warning_count"), [
+        ({ "checks": {
+            "User need links have qw-user-need label": "warning",
+            "User Need links must exist": "error",
+            "Closing Issues are Requirements": "off",
+        }}, "incorrect_links", 1, 2),
+        ({ "checks": {
+            "User need links have qw-user-need label": "off",
+            "User Need links must exist": "off",
+            "Closing Issues are Requirements": "warning",
+        }}, "incorrect_links", 0, 2),
+    ],
+    indirect=["empty_local_store", "test_design_stages"],
+)
+def test_check_severity(
+    qw_store_builder,
+    test_design_stages,
+    expected_error_count,
+    expected_warning_count,
+):
+    store = qw_store_builder(test_design_stages)
+    stages = get_local_stages(store)
+    results = run_checks_with_impacts(store, stages)
+    assert results.object_count == 6
+    assert len(results.errors) == expected_error_count
+    assert len(results.warnings) == expected_warning_count


### PR DESCRIPTION
`conf.json`:

```
{ ...
  "checks": {
    "Closing Issues are Requirements": "warning"
  }
}
```

makes PRs having closing issues that aren't requirements a warning and don't stop PRs from being merge.

Closes #52
